### PR TITLE
Loop through all lines in _csv (list)

### DIFF
--- a/scripts/scrapper.py
+++ b/scripts/scrapper.py
@@ -38,7 +38,7 @@ def _create_matrix(raw):
     with open(_DUMP_CSV, 'w') as csvfile:
         cwriter = csv.writer(csvfile, delimiter=',',
                                 quotechar='"', quoting=csv.QUOTE_MINIMAL)
-        for line in _csv[:-1]:
+        for line in _csv:
             if len(line) < 3:
                 continue
             cwriter.writerow(line)


### PR DESCRIPTION
The last line of compatibilities is not written to the CSV file. This PR fixes that (I hope). You can check this in two ways (well, many more I guess), see way down below. 

Was the idea to get rid of the first line (see below) in the csv?
```
$ head -1 osadl_matrix/osadl-matrix.csv 
Compatibility*,0BSD,AFL-2.0,AFL-2.1,AFL-3.0,AGPL-3.0-only,AGPL-3.0-or-later,Apache-1.0,Apache-1.1,Apache-2.0,Artistic-1.0,Artistic-1.0-Perl,Artistic-2.0,BSD-1-Clause,BSD-2-Clause,BSD-2-Clause-Patent,BSD-3-Clause,BSD-4-Clause,BSD-4-Clause-UC,BSD-Source-Code,BSL-1.0,CC0-1.0,CDDL-1.0,CDDL-1.1,CPL-1.0,EFL-2.0,EPL-1.0,EPL-2.0,EUPL-1.1,EUPL-1.2,FSFAP,FSFULLR,FTL,GPL-1.0-only,GPL-1.0-or-later,GPL-2.0-only,GPL-2.0-only WITH Classpath-exception-2.0,GPL-2.0-or-later,GPL-3.0-only,GPL-3.0-or-later,HPND,IBM-pibs,ICU,IJG,IPL-1.0,ISC,Info-ZIP,LGPL-2.1-only,LGPL-2.1-or-later,LGPL-3.0-only,LGPL-3.0-or-later,Libpng,MIT,MIT-CMU,MPL-1.1,MPL-2.0,MPL-2.0-no-copyleft-exception,MS-PL,MS-RL,MirOS,NBPL-1.0,NTP,OSL-3.0,OpenSSL,PHP-3.01,PostgreSQL,Python-2.0,Qhull,RSA-MD,SunPro,UPL-1.0,Unicode-DFS-2015,Unicode-DFS-2016,Unlicense,W3C,W3C-19980720,W3C-20150513,WTFPL,X11,XFree86-1.1,ZPL-2.0,Zlib,bzip2-1.0.5,bzip2-1.0.6,curl,libtiff,zlib-acknowledgement
```


***Check: count lines with license name***

```
$ ./scripts/scrapper.py 
$ grep -e "BSD-3-Clause" osadl_matrix/osadl-matrix.csv | wc -l
2
$ grep -e "zlib-acknowledgement" osadl_matrix/osadl-matrix.csv | wc -l
1
```
Both should output `2`

***Check: count licenses and compat entries per line***

Using the bash (yeah yeah, I know) code below:
* counts the lines, discarding the first line (i.e LINE contains the number of licenses, today: 86)
* counts how many "," are on each line, including the first item which is the license name (i.e. L_LINE contains the number of compatibilities per row/line, today: 87)
* if the diff is not 1, something is wrong. Prints "Uh oh ..."


```
./scripts/scrapper.py
LINES=$(cat osadl_matrix/osadl-matrix.csv | grep -v "^Compatibility" | wc -l)  
while read LINE; do L_LINES=$(echo $LINE | tr "," "\n" | wc -l); DIFF=$(( $L_LINES - $LINES)); if [ $DIFF -ne 1 ] ; then echo "Uh oh, DIFF=$DIFF ($L_LINES - $LINES)"; fi ;  done < osadl_matrix/osadl-matrix.csv 
```
