### PR TITLE
Add new functionality to provide more fine grained compatibility information

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,16 @@ import osadl_matrix
 
 result = osadl_matrix.is_compatible("BSD-3-Clause", "MIT")
 # result is either
+# True - licenses are compatible
+# False - licenses are *NOT* compatible
+
+result = osadl_matrix.get_compatibility("GPL-2.0-only", "MIT")
+# result is either
 # osadl_matrix.OSADLCompatibility.YES - licenses are compatible
 # osadl_matrix.OSADLCompatibility.NO - licenses are *NOT* compatible
-# osadl_matrix.OSADLCompatibility.UNDEF - no data available on compatibility
+# osadl_matrix.OSADLCompatibility.UNKNOWN - license compatibility is uncertain
+# osadl_matrix.OSADLCompatibility.CHECKDEP - compatibility has depencies that need to be checked
+# osadl_matrix.OSADLCompatibility.UNDEF - at least one of the licenses are not present in the OSADL matrix
 ```
 
 ### Using the raw data

--- a/osadl_matrix/__init__.py
+++ b/osadl_matrix/__init__.py
@@ -1,19 +1,30 @@
 # SPDX-FileCopyrightText: 2021 Konrad Weihmann
+# SPDX-FileCopyrightText: 2022 Henrik Sandklef
 # SPDX-License-Identifier: Unlicensed
 
 import csv
 import os
-from enum import Enum
+from enum import Enum, unique
 
 OSADL_MATRIX = os.path.join(os.path.dirname(__file__), 'osadl-matrix.csv')
 OSADL_MATRIX_JSON = os.path.join(os.path.dirname(__file__), 'osadl-matrix.json')
 __osadl_db = {}
 
 
+@unique
 class OSADLCompatibility(Enum):
-    YES = True
-    NO = False
-    UNDEF = False
+    """
+    YES - licenses are compatible
+    NO - licenses are NOT compatible
+    UNKNOWN - license compatibility is uncertain
+    CHECKDEP - compatibility has depencies that need to be checked
+    UNDEF - at least one of the licenses are not present in the OSADL matrix
+    """
+    YES = 'Yes'
+    NO = 'No'
+    UNKNOWN = 'Unknown'
+    CHECKDEP = 'Check dependency'
+    UNDEF = 'Undefined license'
 
     @staticmethod
     def from_text(_in):
@@ -21,6 +32,10 @@ class OSADLCompatibility(Enum):
             return OSADLCompatibility.YES
         if _in == 'No':
             return OSADLCompatibility.NO
+        if _in == 'Unknown':
+            return OSADLCompatibility.UNKNOWN
+        if _in == 'Check dependency':
+            return OSADLCompatibility.CHECKDEP
         return OSADLCompatibility.UNDEF
 
 
@@ -37,14 +52,34 @@ def __read_db(customdb=None):
 
 
 def is_compatible(outbound, inbound, customdb=None):
-    """checks if the 'outbound' license is compatible with the 'inbound' license
+    """checks if the 'outbound' license is compatible with the 'inbound'
+   license. If the licenses can be found in the matrix and the
+   licenses are compatible, True is returned. In all other cases False
+   is returned.
 
     Args:
         outbound (string): SPDX ID for an outbound license, e.g. the license used for distribution of an application
         inbound (string): SPDX ID for an inbound license, e.g. the license used for a dependency of the application
 
     Returns:
-        [OSADLCompatibility]: Either yes, no or undefined
+        [OSADLCompatibility]: True or False
+
+    """
+    return get_compatibility(outbound, inbound, customdb) == OSADLCompatibility.YES
+
+
+def get_compatibility(outbound, inbound, customdb=None):
+    """returns the compatibility status between the 'outbound' and the
+    'inbound' licenses. If any (or both) of the licenses are not
+    present in the OSADL matrix, then UNDEF is returned.
+
+    Args:
+        outbound (string): SPDX ID for an outbound license, e.g. the license used for distribution of an application
+        inbound (string): SPDX ID for an inbound license, e.g. the license used for a dependency of the application
+
+    Returns:
+        [OSADLCompatibility]: Either yes, no, unknown or undefined
+
     """
     if not __osadl_db:
         __read_db(customdb=customdb)

--- a/tests/test_compat_matrix.py
+++ b/tests/test_compat_matrix.py
@@ -34,15 +34,15 @@ class TestMatrix():
     def test_9(self):
         assert not osadl_matrix.is_compatible("LGPL-2.1-only", "GPL-2.0-only")
 
-    def test_9(self):
+    def test_10(self):
         assert not osadl_matrix.is_compatible("MPL-2.0", "APL-2.0")
 
-    def test_10(self):
+    def test_11(self):
         assert osadl_matrix.get_compatibility("MPL-2.0", "AFL-2.0")  == osadl_matrix.OSADLCompatibility.UNKNOWN
 
-    def test_10(self):
+    def test_12(self):
         assert osadl_matrix.get_compatibility("GPL-2.0-only", "EPL-2.0")  == osadl_matrix.OSADLCompatibility.CHECKDEP
 
-    def test_10(self):
+    def test_13(self):
         assert osadl_matrix.get_compatibility("Unfairy-license", "EPL-2.0")  == osadl_matrix.OSADLCompatibility.UNDEF
 

--- a/tests/test_compat_matrix.py
+++ b/tests/test_compat_matrix.py
@@ -1,33 +1,48 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2021 Konrad Weihmann
+# SPDX-FileCopyrightText: 2022 Henrik Sandklef
 # SPDX-License-Identifier: Unlicensed
 
 import pytest
-
 import osadl_matrix
 
 class TestMatrix():
     def test_1(self):        
-        assert osadl_matrix.is_compatible("MIT", "BSD-3-Clause") == osadl_matrix.OSADLCompatibility.YES
+        assert osadl_matrix.is_compatible("MIT", "BSD-3-Clause")
 
     def test_2(self):
-        assert osadl_matrix.is_compatible("BSD-3-Clause", "MIT") ==  osadl_matrix.OSADLCompatibility.YES
+        assert osadl_matrix.is_compatible("BSD-3-Clause", "MIT")
 
     def test_3(self):
-        assert osadl_matrix.is_compatible("GPL-2.0-only", "BSD-3-Clause") ==  osadl_matrix.OSADLCompatibility.YES
+        assert osadl_matrix.is_compatible("GPL-2.0-only", "BSD-3-Clause")
 
     def test_4(self):
-        assert osadl_matrix.is_compatible("BSD-3-Clause", "GPL-2.0-only") ==  osadl_matrix.OSADLCompatibility.NO
+        assert not osadl_matrix.is_compatible("BSD-3-Clause", "GPL-2.0-only")
 
     def test_5(self):
-        assert osadl_matrix.is_compatible("GPL-2.0-only", "LGPL-2.1-only") ==  osadl_matrix.OSADLCompatibility.YES
+        assert osadl_matrix.is_compatible("GPL-2.0-only", "LGPL-2.1-only")
 
     def test_6(self):
-        assert osadl_matrix.is_compatible("GPL-2.0-only", "GPL-2.0-only") ==  osadl_matrix.OSADLCompatibility.YES
+        assert osadl_matrix.is_compatible("GPL-2.0-only", "GPL-2.0-only")
 
     def test_7(self):
-        assert osadl_matrix.is_compatible("My-Fairy-Little-License", "LGPL-2.1-only") ==  osadl_matrix.OSADLCompatibility.UNDEF
+        assert not osadl_matrix.is_compatible("My-Fairy-Little-License", "LGPL-2.1-only")
 
     def test_8(self):
-        assert osadl_matrix.is_compatible("zlib-acknowledgement", "zlib-acknowledgement") ==  osadl_matrix.OSADLCompatibility.YES
+        assert osadl_matrix.is_compatible("zlib-acknowledgement", "zlib-acknowledgement")
+
+    def test_9(self):
+        assert not osadl_matrix.is_compatible("LGPL-2.1-only", "GPL-2.0-only")
+
+    def test_9(self):
+        assert not osadl_matrix.is_compatible("MPL-2.0", "APL-2.0")
+
+    def test_10(self):
+        assert osadl_matrix.get_compatibility("MPL-2.0", "AFL-2.0")  == osadl_matrix.OSADLCompatibility.UNKNOWN
+
+    def test_10(self):
+        assert osadl_matrix.get_compatibility("GPL-2.0-only", "EPL-2.0")  == osadl_matrix.OSADLCompatibility.CHECKDEP
+
+    def test_10(self):
+        assert osadl_matrix.get_compatibility("Unfairy-license", "EPL-2.0")  == osadl_matrix.OSADLCompatibility.UNDEF
 


### PR DESCRIPTION
get_compatibility - provides more fine grained compatibility information
* YES - licenses are compatible
* NO - licenses are *NOT* compatible
* UNDEF - no data available on compatibility
* UNKNOWN - license compatibility is uncertain
* CHECKDEP - compatibility has depencies that need to be checked
* UNDEF - at least one of the licenses are not present in the OSADL matrix


is_compatible
* True - licenses are compatible
* False - licenses are *NOT* compatible