### PR TITLE
Fix undefined license compatibility

### DIFF
--- a/osadl_matrix/__init__.py
+++ b/osadl_matrix/__init__.py
@@ -36,6 +36,8 @@ class OSADLCompatibility(Enum):
             return OSADLCompatibility.UNKNOWN
         if _in == 'Check dependency':
             return OSADLCompatibility.CHECKDEP
+        if _in == 'Same':
+            return OSADLCompatibility.YES
         return OSADLCompatibility.UNDEF
 
 
@@ -46,8 +48,6 @@ def __read_db(customdb=None):
         for row in _reader:
             key = row['Compatibility*']
             for k, v in row.items():
-                if k == key:
-                    continue
                 __osadl_db[(key, k)] = OSADLCompatibility.from_text(v)
 
 
@@ -83,6 +83,4 @@ def get_compatibility(outbound, inbound, customdb=None):
     """
     if not __osadl_db:
         __read_db(customdb=customdb)
-    if outbound == inbound:
-        return OSADLCompatibility.YES
     return __osadl_db.get((outbound, inbound), OSADLCompatibility.UNDEF)

--- a/tests/test_compat_matrix.py
+++ b/tests/test_compat_matrix.py
@@ -46,3 +46,6 @@ class TestMatrix():
     def test_13(self):
         assert osadl_matrix.get_compatibility("Unfairy-license", "EPL-2.0")  == osadl_matrix.OSADLCompatibility.UNDEF
 
+    def test_14(self):
+        assert osadl_matrix.get_compatibility("A", "A")  == osadl_matrix.OSADLCompatibility.UNDEF
+


### PR DESCRIPTION
If the same undefined licenses is checked for compatibility, "Yes" is  returned even if the license is undefined. 

Better to return UNDEF.
