### PR TITLE
Remove timestamp and timeformat from matrix

### DIFF
--- a/osadl_matrix/__init__.py
+++ b/osadl_matrix/__init__.py
@@ -47,6 +47,10 @@ def __read_db(customdb=None):
         try:
             with open(customdb or OSADL_MATRIX_JSON) as i:
                 __osadl_db = json.load(i)
+                # The below will raise KeyError if any of them are
+                # removed. Keep as is to make sure we detect when keys changes.
+                __osadl_db.pop('timestamp')
+                __osadl_db.pop('timeformat')
         except json.JSONDecodeError:
             if customdb:  # pragma: no cover
                 with open(customdb) as i:

--- a/tests/mini-matrix.json
+++ b/tests/mini-matrix.json
@@ -13,5 +13,7 @@
 	"BSD-3-Clause": "Yes",
 	"Dummy": "Yes",
 	"GPL-2.0-or-later": "Same"
-    }
+    },
+    "timeformat": {},
+    "timestamp": {}
 }


### PR DESCRIPTION
When reading the JSON file, `osadl_matrix.json`, two keys that are not licenses:
* timestamp
* timeformat

When listing the supported licenses, `supported_licenses`, the two above are listed.

With this commit they are removed from the matrix (when reading the JSON file) and thus not listed in the above call.  